### PR TITLE
Remove disabling score submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,6 @@ TransparentWall is made to do one simple thing
 
 These options can be changed from inside the game, so there's no need to edit configuration files.
 
-## Note
-While TransparentWall is enabled in the HMD/VR view, high scores will be temporarily disabled.
-
-By turning this option off again in the settings, high scores will be re-enabled.
-<p align="left">
-  <img src="https://i.imgur.com/gWxKjQK.jpg" width="650" title="scoresubdisable">
-</p>
-
 ## For developers
 
 ### Contributing to TransparentWall

--- a/TransparentWall/Gameplay/TransparentWalls.cs
+++ b/TransparentWall/Gameplay/TransparentWalls.cs
@@ -14,11 +14,6 @@ namespace TransparentWall.Gameplay
         [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Unity calls this")]
         private void Start()
         {
-            if (Configuration.EnableForHeadset)
-            {
-                ScoreSubmission.DisableSubmission(Plugin.PluginName);
-            }
-
             if (!Configuration.DisableForLivCamera) return;
 
             if (Resources.FindObjectsOfTypeAll<MoveBackWall>().Any())

--- a/TransparentWall/Resources/description.md
+++ b/TransparentWall/Resources/description.md
@@ -1,7 +1,3 @@
 ﻿#### Features
 Enable transparent walls in the HMD/VR view
 Disable the transparent walls for the LIV camera
-
-#### Note
-While TransparentWall is enabled in the HMD/VR view, high scores will be temporarily disabled.
-By turning this option off again in the settings, high scores will be re-enabled.

--- a/TransparentWall/Settings/UI/Views/mainmodifiers.bsml
+++ b/TransparentWall/Settings/UI/Views/mainmodifiers.bsml
@@ -1,7 +1,6 @@
 ﻿<bg xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='https://monkeymanboy.github.io/BSML-Docs/ https://raw.githubusercontent.com/monkeymanboy/BSML-Docs/gh-pages/BSMLSchema.xsd'>
   <modifier-container pref-width='50' pref-height='5'>
     <modifier text='Enable in headsett' value='enable-headset'
-              hover-hint='Disables ScoreSubmission when enabled'
               source='TransparentWall.Resources.icon_playersettings.png'
               on-change='trigger-headset-toggle'/>
     <modifier text='Disable in LIV' value='disable-liv'

--- a/TransparentWall/Settings/UI/Views/mainsettings.bsml
+++ b/TransparentWall/Settings/UI/Views/mainsettings.bsml
@@ -3,7 +3,6 @@
     <text text='Transparent Walls Settings' font-size='5' />
   </horizontal>
 
-  <bool-setting text='Enable in HMD/Headset' value='enable-in-hmd'
-                hover-hint='Enabling this option will deactivate score submission until it&apos;s turned off again!' />
+  <bool-setting text='Enable in HMD/Headset' value='enable-in-hmd' />
   <bool-setting text='Disable in LIV Camera' value='disable-in-liv' />
 </settings-container>


### PR DESCRIPTION
Overall, I feel as if keeping this is honestly a legacy thing. There really isn't a point in keeping disabling score submission, especially when disabling screen distortion already yields almost-transparent walls.