### PR TITLE
Fix NullRef on no HMD

### DIFF
--- a/TransparentWall/HarmonyPatches/Patches/ObstacleControllerCullingLayer.cs
+++ b/TransparentWall/HarmonyPatches/Patches/ObstacleControllerCullingLayer.cs
@@ -14,7 +14,11 @@ namespace TransparentWall.HarmonyPatches.Patches
         {
             if (!Configuration.EnableForHeadset)
             {
-                Camera.main?.cullingMask |= 1 << Configuration.WallLayerMask;
+                Camera cam = Camera.main;
+				if (cam != null)
+				{
+					cam.cullingMask |= 1 << Configuration.WallLayerMask;
+				}
             }
         }
 
@@ -24,7 +28,11 @@ namespace TransparentWall.HarmonyPatches.Patches
         {
             if (Configuration.EnableForHeadset)
             {
-                Camera.main?.cullingMask &= ~(1 << Configuration.WallLayerMask);
+                Camera cam = Camera.main;
+				if (cam != null)
+				{
+					cam.cullingMask &= ~(1 << Configuration.WallLayerMask);
+				}
             }
 
             if (Configuration.EnableForHeadset || Configuration.DisableForLivCamera)

--- a/TransparentWall/HarmonyPatches/Patches/ObstacleControllerCullingLayer.cs
+++ b/TransparentWall/HarmonyPatches/Patches/ObstacleControllerCullingLayer.cs
@@ -14,7 +14,7 @@ namespace TransparentWall.HarmonyPatches.Patches
         {
             if (!Configuration.EnableForHeadset)
             {
-                Camera.main.cullingMask |= 1 << Configuration.WallLayerMask;
+                Camera.main?.cullingMask |= 1 << Configuration.WallLayerMask;
             }
         }
 
@@ -24,7 +24,7 @@ namespace TransparentWall.HarmonyPatches.Patches
         {
             if (Configuration.EnableForHeadset)
             {
-                Camera.main.cullingMask &= ~(1 << Configuration.WallLayerMask);
+                Camera.main?.cullingMask &= ~(1 << Configuration.WallLayerMask);
             }
 
             if (Configuration.EnableForHeadset || Configuration.DisableForLivCamera)


### PR DESCRIPTION
Camera2 has all Desktop-Camera behaviours disabled and manually paces Render() to allow things like FPS limiting. When no Headset is connected, Camera.main will thus yield null and cause this bug https://github.com/kinsi55/CS_BeatSaber_Camera2/issues/41